### PR TITLE
部分spa切换路由时onPageStared没监听到

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java
@@ -461,6 +461,13 @@ public class DefaultWebClient extends MiddlewareWebClientBase {
 
 	}
 
+	@Override
+	public void doUpdateVisitedHistory(WebView view, String url, boolean isReload) {
+		if (!mWaittingFinishSet.contains(url)) {
+			mWaittingFinishSet.add(url);
+		}
+		super.doUpdateVisitedHistory(view, url, isReload);
+	}
 
 	/**
 	 * MainFrame Error


### PR DESCRIPTION
因此导致有时页面重定向了，onPageFinished拿到的是重定向后地址，mWaittingFinishSet没找到对应url

会导致发生错误时reload后重定向引起errorLayout不隐藏

类似#653的错误