### PR TITLE
fix NPE when call onRequestPermissionsResult after ActionActivity recreate

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/ActionActivity.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/ActionActivity.java
@@ -73,12 +73,12 @@ public final class ActionActivity extends Activity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Intent intent = getIntent();
+        mAction = intent.getParcelableExtra(KEY_ACTION);
         if (savedInstanceState != null) {
             LogUtils.i(TAG, "savedInstanceState:" + savedInstanceState);
             return;
         }
-        Intent intent = getIntent();
-        mAction = intent.getParcelableExtra(KEY_ACTION);
         if (mAction == null) {
             cancelAction();
             this.finish();


### PR DESCRIPTION
请求权限回来后ActionActivity重建了mAction=null ，导致回调onRequestPermissionsResult方法时调mAction.getFromIntention()报空指针异常