### PR TITLE
fix(DefaultUIController): guard SSL-error dialog against finishing activity (#1065)

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/DefaultUIController.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/DefaultUIController.java
@@ -367,6 +367,15 @@ public class DefaultUIController extends AbsAgentWebUIController {
 
 	@Override
 	public void onShowSslCertificateErrorDialog(final WebView view, final SslErrorHandler handler, final SslError error) {
+		// Issue #1065: Activity may already be finishing/destroyed by the time the
+		// WebView delivers the SSL error callback on the main thread. Showing a
+		// dialog against a stale window token throws WindowManager$BadTokenException.
+		// Fail safe by cancelling the request when we cannot present UI.
+		if (mActivity == null || mActivity.isFinishing()
+				|| (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && mActivity.isDestroyed())) {
+			handler.cancel();
+			return;
+		}
 		AlertDialog.Builder alertDialog = new AlertDialog.Builder(mActivity);
 		String sslErrorMessage;
 		switch (error.getPrimaryError()) {
@@ -402,7 +411,18 @@ public class DefaultUIController extends AbsAgentWebUIController {
 				handler.cancel();
 			}
 		});
-		alertDialog.show();
+		// Re-check just before show in case the activity transitioned during string lookup.
+		if (mActivity.isFinishing()
+				|| (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && mActivity.isDestroyed())) {
+			handler.cancel();
+			return;
+		}
+		try {
+			alertDialog.show();
+		} catch (android.view.WindowManager.BadTokenException | IllegalStateException e) {
+			// Activity window went away between our check and show(); fail safe.
+			handler.cancel();
+		}
 
 
 	}


### PR DESCRIPTION
## Guard the SSL-error dialog against a finishing/destroyed activity

Resolves #1065 - `WindowManager$BadTokenException` from
`DefaultUIController.onShowSslCertificateErrorDialog`.

### What was happening

The crash trace in the issue ends in `AlertDialog$Builder.show(...)` from
`DefaultUIController.onShowSslCertificateErrorDialog`. The reporter notes
that the surrounding methods (e.g. `onLoading`, `onCancelLoading`) already
guard against `Activity#isFinishing`, but `onShowSslCertificateErrorDialog`
did not. Because `WebView` delivers `onReceivedSslError` on the main thread
asynchronously, `mActivity` may have started its finish/destroy teardown
before the dialog is shown, and adding a window with a stale token throws
`BadTokenException`.

### Fix

`agentweb-core/src/main/java/com/just/agentweb/DefaultUIController.java`:

1. Before building the dialog, return early with `handler.cancel()` if
   `mActivity` is `null`, `isFinishing()`, or (API ≥17) `isDestroyed()`.
2. Re-run the same check immediately before `AlertDialog.show()` to close
   the small race between building the dialog and showing it.
3. Wrap the `show()` call in a `try`/`catch` for
   `WindowManager.BadTokenException` and `IllegalStateException` so any
   residual race fails safely rather than crashing.

Failing safe means cancelling the SSL request, i.e. **not** silently
accepting an untrusted certificate when we can't ask the user.
