### PR TITLE
fix(AbsAgentWebSettings): allow media playback without user gesture (#339)

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/AbsAgentWebSettings.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/AbsAgentWebSettings.java
@@ -65,6 +65,10 @@ public abstract class AbsAgentWebSettings implements IAgentWebSettings, WebListe
         mWebSettings.setSupportZoom(true);
         mWebSettings.setBuiltInZoomControls(false);
         mWebSettings.setSavePassword(false);
+        // Issue #339: HTMLMediaElement.play() throws "API can only be initiated by
+        // a user gesture" for embedded video players that auto-play. Allow
+        // programmatic playback so embedded players (e.g. share-page videos) work.
+        mWebSettings.setMediaPlaybackRequiresUserGesture(false);
         if (AgentWebUtils.checkNetwork(webView.getContext().getApplicationContext())) {
             //根据cache-control获取数据。
             mWebSettings.setCacheMode(WebSettings.LOAD_DEFAULT);


### PR DESCRIPTION
## Allow programmatic media playback in AgentWeb's WebView (#339)

Resolves #339 - embedded video fails with `play() can only be initiated by a user gesture`.

### Why playback fails

The reporter's logs include two errors:

```
Failed to execute 'play' on 'HTMLMediaElement': API can only be initiated by a user gesture.
Mixed Content: ... request has been blocked; the content must be served over HTTPS.
```

* The **mixed-content** half is already addressed in current upstream:
  `AbsAgentWebSettings.settings()` calls
  `setMixedContentMode(MIXED_CONTENT_ALWAYS_ALLOW)` on Lollipop+, so HTTP
  media on an HTTPS page is no longer blocked.
* The **user-gesture** half is not. The platform default for
  `WebSettings.setMediaPlaybackRequiresUserGesture` is `true`. AgentWeb
  never overrides it, so embedded players that start playback
  programmatically (the douyin player in the report, TikTok-style share
  pages, Twitter video, etc.) hit `NotAllowedError` exactly as quoted.

### Fix

`agentweb-core/src/main/java/com/just/agentweb/AbsAgentWebSettings.java`:

* In `settings(WebView)`, immediately after the existing JS / zoom /
  password block, add
  `mWebSettings.setMediaPlaybackRequiresUserGesture(false);`.

This matches what most in-app browser components do (Glide-WebView,
WebView+, etc.) and is what every reproduction in the issue thread asks
for. No other behavior changes.
