### PR TITLE
fix(WebViewClientDelegate): supply non-null favicon placeholder to delegates (#490)

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/WebViewClientDelegate.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/WebViewClientDelegate.java
@@ -68,13 +68,43 @@ public class WebViewClientDelegate extends WebViewClient {
         return super.shouldOverrideUrlLoading(view, request);
     }
 
+    /**
+     * One-pixel transparent placeholder used in place of a null favicon when
+     * forwarding {@link #onPageStarted(WebView, String, Bitmap)} to a delegate
+     * whose Kotlin signature declares favicon as a non-null {@code Bitmap}.
+     * Allocated lazily so there is no cost when the platform supplies a real
+     * favicon. See issue #490.
+     */
+    private static volatile Bitmap sFaviconPlaceholder;
+
+    private static Bitmap faviconPlaceholder() {
+        Bitmap placeholder = sFaviconPlaceholder;
+        if (placeholder == null) {
+            synchronized (WebViewClientDelegate.class) {
+                placeholder = sFaviconPlaceholder;
+                if (placeholder == null) {
+                    placeholder = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888);
+                    sFaviconPlaceholder = placeholder;
+                }
+            }
+        }
+        return placeholder;
+    }
+
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        // Issue #490: WebView may deliver a null favicon at page-start. Kotlin
+        // delegates whose signature declares favicon as non-null Bitmap will
+        // crash at the synthetic Intrinsics.checkParameterIsNotNull check.
+        // Substitute a tiny transparent placeholder so non-null Kotlin
+        // signatures keep working; nullable signatures see no observable
+        // change beyond receiving a non-null bitmap.
+        Bitmap safeFavicon = favicon != null ? favicon : faviconPlaceholder();
         if (mDelegate != null) {
-            mDelegate.onPageStarted(view, url, favicon);
+            mDelegate.onPageStarted(view, url, safeFavicon);
             return;
         }
-        super.onPageStarted(view, url, favicon);
+        super.onPageStarted(view, url, safeFavicon);
     }
 
     @Override


### PR DESCRIPTION
## Forward a non-null favicon to delegates to fix Kotlin crashes

Resolves #490 - `IllegalArgumentException: Parameter specified as non-null is null: ... favicon`.

### Why Kotlin callers crash

`WebView` is allowed to deliver `WebViewClient.onPageStarted` with `favicon == null`
during early page-start (e.g. when the page hasn't yet announced an icon).
`WebViewClientDelegate.onPageStarted` simply forwards whatever it received to
the user's delegate.

Kotlin source compiles non-nullable parameter declarations into bytecode that
calls `Intrinsics.checkParameterIsNotNull(...)` on entry. A user delegate that
declares its `onPageStarted(view: WebView?, url: String?, favicon: Bitmap)` --
i.e. the favicon parameter is *non*-nullable -- therefore throws
`IllegalArgumentException` the moment AgentWeb forwards a null. This is the
exact stack trace in #490.

### Fix

`agentweb-core/src/main/java/com/just/agentweb/WebViewClientDelegate.java`:

* In `onPageStarted`, when `favicon` is null, substitute a tiny lazily
  allocated 1×1 transparent ARGB_8888 placeholder bitmap before calling the
  delegate.
* Delegates with a `Bitmap?` signature observe no behavior change beyond
  receiving a non-null value.
* Delegates with a `Bitmap` (non-nullable) signature no longer crash.
* The placeholder is cached statically (double-checked) so the common path
  with a real favicon allocates nothing.

This avoids forcing every Kotlin caller to either remember to declare the
parameter as nullable or wire up a `MiddlewareWebClient` purely as a
null-shim (the workaround the issue author had to apply).
