### PR TITLE
fix(DefaultWebClient): allow file:// and javascript: navigations to fall through (#762)

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java
@@ -147,6 +147,14 @@ public class DefaultWebClient extends MiddlewareWebClientBase {
 	 */
 	public static final String SCHEME_SMS = "sms:";
 	/**
+	 * file scheme - locally bundled assets and on-device files.
+	 */
+	public static final String FILE_SCHEME = "file://";
+	/**
+	 * javascript: scheme - bookmarklet-style URLs the WebView itself evaluates.
+	 */
+	public static final String JAVASCRIPT_SCHEME = "javascript:";
+	/**
 	 * 缓存当前出现错误的页面
 	 */
 	private Set<String> mErrorUrlsSet = new HashSet<>();
@@ -188,6 +196,13 @@ public class DefaultWebClient extends MiddlewareWebClientBase {
 		String url = request.getUrl().toString();
 		if (url.startsWith(HTTP_SCHEME) || url.startsWith(HTTPS_SCHEME)) {
 			return (webClientHelper && HAS_ALIPAY_LIB && isAlipay(view, url));
+		}
+		// Issue #762: navigations to file:// (e.g. links between bundled assets)
+		// and javascript: URLs must be handled by WebView itself. Letting them
+		// fall through into the unknown-URL branch below causes
+		// mIsInterceptUnkownUrl to silently drop the navigation.
+		if (url.startsWith(FILE_SCHEME) || url.startsWith(JAVASCRIPT_SCHEME)) {
+			return false;
 		}
 		if (!webClientHelper) {
 			return super.shouldOverrideUrlLoading(view, request);
@@ -277,6 +292,13 @@ public class DefaultWebClient extends MiddlewareWebClientBase {
 	public boolean shouldOverrideUrlLoading(WebView view, String url) {
 		if (url.startsWith(HTTP_SCHEME) || url.startsWith(HTTPS_SCHEME)) {
 			return (webClientHelper && HAS_ALIPAY_LIB && isAlipay(view, url));
+		}
+		// Issue #762: navigations to file:// (e.g. links between bundled assets)
+		// and javascript: URLs must be handled by WebView itself. Letting them
+		// fall through into the unknown-URL branch below causes
+		// mIsInterceptUnkownUrl to silently drop the navigation.
+		if (url.startsWith(FILE_SCHEME) || url.startsWith(JAVASCRIPT_SCHEME)) {
+			return false;
 		}
 		if (!webClientHelper) {
 			return false;


### PR DESCRIPTION
## Let `file://` (and `javascript:`) navigations fall through to WebView

Resolves #762 - clicking a link inside a `file:///android_asset/...` page
does nothing.

### Why nothing happens

`DefaultWebClient.shouldOverrideUrlLoading` is structured as:

```
if (http or https)               -> handle alipay or super
if (!webClientHelper)            -> super
if (handleCommonLink(url))       -> true     (tel, mailto, sms, geo, ...)
if (intent: / weixin: / alipays: / deeplink) -> true
if (mIsInterceptUnkownUrl)       -> true     <-- swallows everything else
return super(...)
```

`mIsInterceptUnkownUrl` is `true` by default, so any URL that doesn't
match http/https/tel/mailto/intent/weixin/alipays falls into the final
catch-all and returns `true` — telling `WebView` *"I handled this, do
not load it"*. `file:///android_asset/social/h5/other.html` and
`javascript:` URLs both end up there, which is why the user's `<a>`
link to a sibling local page silently does nothing.

### Fix

`agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java`:

* Adds two scheme constants near `SCHEME_SMS`:
  ```java
  public static final String FILE_SCHEME = "file://";
  public static final String JAVASCRIPT_SCHEME = "javascript:";
  ```
* Both overloads of `shouldOverrideUrlLoading` (the modern
  `WebResourceRequest` one and the legacy `String` one) return `false`
  as soon as they see one of those schemes, letting `WebView` perform
  the navigation itself.

This is the minimal change that restores in-page navigation for
locally-bundled HTML without weakening the existing intent/alipay/wechat
interception behavior.
