### PR TITLE
Allow HTML5 video autoplay inside AgentWeb (closes #339)

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/AbsAgentWebSettings.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/AbsAgentWebSettings.java
@@ -96,6 +96,11 @@ public abstract class AbsAgentWebSettings implements IAgentWebSettings, WebListe
             mWebSettings.setAllowUniversalAccessFromFileURLs(false);
         }
         mWebSettings.setJavaScriptCanOpenWindowsAutomatically(true);
+        // Issue #339: HTML5 video.play() was rejected with
+        // "play() can only be initiated by a user gesture" because the default
+        // gesture requirement was never lifted. Pages that auto-start video
+        // playback (most short-form video sites) need this off.
+        mWebSettings.setMediaPlaybackRequiresUserGesture(false);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
 
             mWebSettings.setLayoutAlgorithm(WebSettings.LayoutAlgorithm.SINGLE_COLUMN);


### PR DESCRIPTION
## Let HTML5 video autoplay inside AgentWeb

Closes #339

### What changed

`agentweb-core/src/main/java/com/just/agentweb/AbsAgentWebSettings.java`

Call `WebSettings.setMediaPlaybackRequiresUserGesture(false)` from the default settings pipeline. Without this, every `video.play()` triggered by JavaScript on the loaded page was rejected by Chromium with the well-known message "play() can only be initiated by a user gesture", which is exactly what the reporter saw on the douyin reflow page.

The existing call to `setMixedContentMode(MIXED_CONTENT_ALWAYS_ALLOW)` already handles the "Mixed Content" half of the same trace. With both flags in place the same page now plays back normally.

### Key snippet

```java
mWebSettings.setJavaScriptCanOpenWindowsAutomatically(true);
mWebSettings.setMediaPlaybackRequiresUserGesture(false);
```

### Notes

The flag is documented as having no effect for Web Audio in some Chromium versions. That is acceptable here because the issue is about HTML5 `<video>` playback. Apps that want to keep the Chromium default can override `AgentWebSettingsImpl.toSetting` and re-enable the gesture requirement.
