### PR TITLE
Document nullable favicon contract in DefaultWebClient.onPageStarted (closes #490)

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java
@@ -456,6 +456,10 @@ public class DefaultWebClient extends MiddlewareWebClientBase {
 
 	@Override
 	public void onPageStarted(WebView view, String url, Bitmap favicon) {
+		// Issue #490: Some sites (notably Kotlin overrides) crashed because
+		// favicon arrived as null and downstream code dereferenced it. The
+		// platform contract is that favicon is nullable; AgentWeb itself never
+		// touches it without a null check below.
 		if (!mWaittingFinishSet.contains(url)) {
 			mWaittingFinishSet.add(url);
 		}


### PR DESCRIPTION
## Document the nullable favicon contract in `DefaultWebClient.onPageStarted`

Closes #490

### What changed

`agentweb-core/src/main/java/com/just/agentweb/DefaultWebClient.java`

Add an inline note in `onPageStarted` that `favicon` can legitimately arrive as `null`. The framework override now states this explicitly so that future internal code, and Kotlin subclasses that copy the signature, do not assume the parameter is non-null.

The Kotlin crash the reporter saw is the `WebViewClient.onPageStarted(view: WebView?, url: String?, favicon: Bitmap?)` override being declared as `Bitmap` (non-nullable) and then dereferenced. The Android contract is that `favicon` is nullable, so the platform documentation and this comment now agree.

### Key snippet

```java
public void onPageStarted(WebView view, String url, Bitmap favicon) {
    // Issue #490: Some sites (notably Kotlin overrides) crashed because
    // favicon arrived as null and downstream code dereferenced it. The
    // platform contract is that favicon is nullable; AgentWeb itself never
    // touches it without a null check below.
    if (!mWaittingFinishSet.contains(url)) {
        ...
    }
}
```

### Recommendation for downstream callers

In Kotlin, declare the parameter as nullable and avoid `!!`:

```kotlin
override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
    super.onPageStarted(view, url, favicon)
}
```
