### PR TITLE
Guard SSL error dialog with isFinishing in DefaultUIController (closes #1065)

### DIFF
--- a/agentweb-core/src/main/java/com/just/agentweb/DefaultUIController.java
+++ b/agentweb-core/src/main/java/com/just/agentweb/DefaultUIController.java
@@ -367,6 +367,14 @@ public class DefaultUIController extends AbsAgentWebUIController {
 
 	@Override
 	public void onShowSslCertificateErrorDialog(final WebView view, final SslErrorHandler handler, final SslError error) {
+		Activity mActivity;
+		if ((mActivity = this.mActivity) == null || mActivity.isFinishing()) {
+			// Issue #1065: Avoid BadTokenException when the host activity has
+			// already started finishing. Mirror the guard used by every other
+			// dialog method in this class (onLoading, onCancelLoading, ...).
+			handler.cancel();
+			return;
+		}
 		AlertDialog.Builder alertDialog = new AlertDialog.Builder(mActivity);
 		String sslErrorMessage;
 		switch (error.getPrimaryError()) {


### PR DESCRIPTION
## Guard the SSL error dialog with `isFinishing` in `DefaultUIController`

Closes #1065

### What changed

`agentweb-core/src/main/java/com/just/agentweb/DefaultUIController.java`

`onShowSslCertificateErrorDialog` now uses the same `mActivity == null || mActivity.isFinishing()` guard that every other dialog method in this class already has (`onLoading`, `onCancelLoading`, `onForceDownloadAlert`, and so on). When the activity is on its way out we cancel the SSL handler instead of attempting to attach a dialog to a dead window token.

This is the exact crash the reporter captured:

```
android.view.WindowManager$BadTokenException: Unable to add window
  -- token android.os.BinderProxy@... is not valid; is your activity running?
  at com.just.agentweb.DefaultUIController.onShowSslCertificateErrorDialog
```

### Key snippet

```java
public void onShowSslCertificateErrorDialog(final WebView view, final SslErrorHandler handler, final SslError error) {
    Activity mActivity;
    if ((mActivity = this.mActivity) == null || mActivity.isFinishing()) {
        handler.cancel();
        return;
    }
    AlertDialog.Builder alertDialog = new AlertDialog.Builder(mActivity);
    ...
}
```

Cancelling the handler matches the existing user choice of "Cancel" on the dialog, which is the safe default for an SSL error.
