### PR TITLE
Ship consumer-rules.pro so JS bridge methods survive R8 (closes #1072)

### DIFF
--- a/agentweb-core/build.gradle
+++ b/agentweb-core/build.gradle
@@ -13,6 +13,9 @@ android {
         versionName VERSION_NAME
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        // Issue #1072: ship Proguard/R8 rules so consumer apps do not have to
+        // re-declare the @JavascriptInterface keep rule themselves.
+        consumerProguardFiles 'consumer-rules.pro'
 
     }
 

--- a/agentweb-core/consumer-rules.pro
+++ b/agentweb-core/consumer-rules.pro
@@ -1,0 +1,14 @@
+# Consumer Proguard/R8 rules for AgentWeb.
+#
+# Issue #1072: in release builds the JS bridge methods were stripped because
+# the host app did not have a keep rule for @JavascriptInterface. AgentWeb
+# itself uses reflection-style discovery on these methods, so the rule needs
+# to apply to every consumer that ships the library.
+
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+
+# AgentWeb's own bridge plumbing relies on reflection over its public API.
+-keep class com.just.agentweb.** { *; }
+-dontwarn com.just.agentweb.**


### PR DESCRIPTION
## Ship `consumer-rules.pro` so JS bridge methods survive R8

Closes #1072

### What changed

`agentweb-core/build.gradle` and a new `agentweb-core/consumer-rules.pro`.

AgentWeb keeps its own classes via the existing `proguard-rules.pro`, but consumer apps that turn on R8 in release builds were not getting any keep rule for `@JavascriptInterface` methods on their own bridge classes. The result was the exact crash the reporter saw:

```
com.just.agentweb.JsInterfaceObjectException: this object has not offer method
javascript to call, please check addJavascriptInterface annotation was be added
```

debug builds ran fine because R8 was disabled there. Release APKs failed because the bridge methods had been removed.

The fix ships consumer rules with the AAR so every app that depends on AgentWeb gets the right keep rule automatically. The new file also re-keeps `com.just.agentweb.**` to defend against R8 trimming AgentWeb itself when the consumer app uses aggressive shrink configurations.

### Key snippet

`agentweb-core/build.gradle`

```groovy
defaultConfig {
    ...
    consumerProguardFiles 'consumer-rules.pro'
}
```

`agentweb-core/consumer-rules.pro`

```
-keepclassmembers class * {
    @android.webkit.JavascriptInterface <methods>;
}

-keep class com.just.agentweb.** { *; }
-dontwarn com.just.agentweb.**
```

### How consumers verify

Build a release APK with `minifyEnabled true`, run the app, and call any `@JavascriptInterface` method from the loaded page. The call now resolves instead of throwing `JsInterfaceObjectException`.
